### PR TITLE
Snake case idl

### DIFF
--- a/src/anchorpy/coder/common.py
+++ b/src/anchorpy/coder/common.py
@@ -1,7 +1,6 @@
 """Common utilities for encoding and decoding."""
 from typing import Dict, Union
 from hashlib import sha256
-from inflection import underscore
 
 from anchorpy.idl import (
     Idl,
@@ -23,7 +22,7 @@ def sighash(namespace: str, ix_name: str) -> bytes:
     """Not technically sighash, since we don't include the arguments.
 
     (Because Rust doesn't allow function overloading.)"""
-    formatted_str = f"{namespace}:{underscore(ix_name)}"
+    formatted_str = f"{namespace}:{ix_name}"
     return sha256(formatted_str.encode()).digest()[:8]
 
 

--- a/src/anchorpy/idl.py
+++ b/src/anchorpy/idl.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, field
 from typing import List, Union, Optional, Dict, Any, Literal, Tuple, TypedDict
 
 from apischema import deserialize, alias
+from apischema.metadata import conversion
+from inflection import underscore, camelize
 from borsh_construct import CStruct, Vec, U8
 import solana.publickey  # noqa: WPS301
 
@@ -28,6 +30,7 @@ NonLiteralIdlTypes = Union[
     "IdlTypeVec", "IdlTypeOption", "IdlTypeDefined", "IdlTypeArray"
 ]
 IdlType = Union[LiteralStrings, NonLiteralIdlTypes]
+snake_case_conversion = conversion(underscore, camelize)
 
 
 @dataclass
@@ -47,13 +50,13 @@ class IdlTypeDefined:
 
 @dataclass
 class IdlField:
-    name: str
+    name: str = field(metadata=snake_case_conversion)
     type: IdlType
 
 
 @dataclass
 class IdlAccount:
-    name: str
+    name: str = field(metadata=snake_case_conversion)
     is_mut: bool = field(metadata=alias("isMut"))
     is_signer: bool = field(metadata=alias("isSigner"))
 
@@ -61,7 +64,7 @@ class IdlAccount:
 @dataclass
 class IdlAccounts:
     # Nested/recursive version of IdlAccount
-    name: str
+    name: str = field(metadata=snake_case_conversion)
     accounts: List["IdlAccountItem"]
 
 
@@ -70,7 +73,7 @@ IdlAccountItem = Union[IdlAccounts, IdlAccount]
 
 @dataclass
 class IdlInstruction:
-    name: str
+    name: str = field(metadata=snake_case_conversion)
     accounts: List[IdlAccountItem]
     args: List[IdlField]
 

--- a/tests/test_basic_1.py
+++ b/tests/test_basic_1.py
@@ -30,9 +30,9 @@ async def initialized_account(program: Program) -> Keypair:
         1234,
         ctx=Context(
             accounts={
-                "myAccount": my_account.public_key,
+                "my_account": my_account.public_key,
                 "user": program.provider.wallet.public_key,
-                "systemProgram": SYS_PROGRAM_ID,
+                "system_program": SYS_PROGRAM_ID,
             },
             signers=[my_account],
         ),
@@ -58,7 +58,7 @@ async def test_update_previously_created_account(
     """Test updating a previously created account."""
     await program.rpc["update"](
         4321,
-        ctx=Context(accounts={"myAccount": initialized_account.public_key}),
+        ctx=Context(accounts={"my_account": initialized_account.public_key}),
     )
     account = await program.account["MyAccount"].fetch(initialized_account.public_key)
     assert account.data == 4321

--- a/tests/test_basic_2.py
+++ b/tests/test_basic_2.py
@@ -38,7 +38,7 @@ async def created_counter(program: Program, provider: Provider) -> Keypair:
             accounts={
                 "counter": counter.public_key,
                 "user": provider.wallet.public_key,
-                "systemProgram": SYS_PROGRAM_ID,
+                "system_program": SYS_PROGRAM_ID,
             },
             signers=[counter],
         ),

--- a/tests/test_basic_3.py
+++ b/tests/test_basic_3.py
@@ -42,17 +42,17 @@ async def test_cpi(workspace: Dict[str, Program], provider: Provider) -> None:
             accounts={
                 "puppet": new_puppet_account.public_key,
                 "user": provider.wallet.public_key,
-                "systemProgram": SYS_PROGRAM_ID,
+                "system_program": SYS_PROGRAM_ID,
             },
             signers=[new_puppet_account],
         ),
     )
-    await puppet_master.rpc["pullStrings"](
+    await puppet_master.rpc["pull_strings"](
         111,
         ctx=Context(
             accounts={
                 "puppet": new_puppet_account.public_key,
-                "puppetProgram": puppet.program_id,
+                "puppet_program": puppet.program_id,
             },
         ),
     )

--- a/tests/test_cashiers_check.py
+++ b/tests/test_cashiers_check.py
@@ -72,18 +72,18 @@ async def create_check(program: Program, initial_state: InitialState) -> Created
     accounts = {
         "check": check.public_key,
         "vault": vault.public_key,
-        "checkSigner": check_signer,
+        "check_signer": check_signer,
         "from": initial_state.god,
         "to": initial_state.receiver,
         "owner": program.provider.wallet.public_key,
-        "tokenProgram": TOKEN_PROGRAM_ID,
+        "token_program": TOKEN_PROGRAM_ID,
         "rent": SYSVAR_RENT_PUBKEY,
     }
     instructions = [
         await program.account["Check"].create_instruction(check, 300),
         *token_account_instrs,
     ]
-    await program.rpc["createCheck"](
+    await program.rpc["create_check"](
         100,
         "Hello world",
         nonce,
@@ -120,15 +120,15 @@ async def test_cash_check(
     initial_state: InitialState,
     create_check: CreatedCheck,
 ) -> None:
-    await program.rpc["cashCheck"](
+    await program.rpc["cash_check"](
         ctx=Context(
             accounts={
                 "check": create_check.check.public_key,
                 "vault": create_check.vault.public_key,
-                "checkSigner": create_check.signer,
+                "check_signer": create_check.signer,
                 "to": initial_state.receiver,
                 "owner": provider.wallet.public_key,
-                "tokenProgram": TOKEN_PROGRAM_ID,
+                "token_program": TOKEN_PROGRAM_ID,
             },
         )
     )

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -34,11 +34,11 @@ async def provider(program: Program) -> Provider:
 @fixture(scope="module")
 async def created_chatroom(program: Program) -> Keypair:
     chatroom = Keypair()
-    await program.rpc["createChatRoom"](
+    await program.rpc["create_chat_room"](
         "Test Chat",
         ctx=Context(
             accounts={
-                "chatRoom": chatroom.public_key,
+                "chat_room": chatroom.public_key,
                 "rent": SYSVAR_RENT_PUBKEY,
             },
             instructions=[
@@ -56,14 +56,14 @@ async def created_user(
 ) -> Tuple[PublicKey, PublicKey]:
     authority = program.provider.wallet.public_key
     user, bump = PublicKey.find_program_address([bytes(authority)], program.program_id)
-    await program.rpc["createUser"](
+    await program.rpc["create_user"](
         "My User",
         bump,
         ctx=Context(
             accounts={
                 "user": user,
                 "authority": authority,
-                "systemProgram": SYS_PROGRAM_ID,
+                "system_program": SYS_PROGRAM_ID,
             }
         ),
     )
@@ -84,13 +84,13 @@ async def sent_messages(
     ]
     for i, msg in enumerate(messages):
         print(f"sending message {i}")
-        await program.rpc["sendMessage"](
+        await program.rpc["send_message"](
             msg,
             ctx=Context(
                 accounts={
                     "user": user,
                     "authority": authority,
-                    "chatRoom": created_chatroom.public_key,
+                    "chat_room": created_chatroom.public_key,
                 },
             ),
         )

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -31,8 +31,8 @@ async def initialized_accounts(program: Program) -> Tuple[Keypair, Keypair]:
     await program.rpc["initialize"](
         ctx=Context(
             accounts={
-                "dummyA": dummy_a.public_key,
-                "dummyB": dummy_b.public_key,
+                "dummy_a": dummy_a.public_key,
+                "dummy_b": dummy_b.public_key,
                 "rent": SYSVAR_RENT_PUBKEY,
             },
             signers=[dummy_a, dummy_b],
@@ -50,15 +50,15 @@ async def composite_updated_accounts(
     program: Program,
     initialized_accounts: Tuple[Keypair, Keypair],
 ) -> Tuple[Keypair, Keypair]:
-    """Run compositeUpdate and return the keypairs used."""
+    """Run composite_update and return the keypairs used."""
     dummy_a, dummy_b = initialized_accounts
     ctx = Context(
         accounts={
-            "foo": {"dummyA": dummy_a.public_key},
-            "bar": {"dummyB": dummy_b.public_key},
+            "foo": {"dummy_a": dummy_a.public_key},
+            "bar": {"dummy_b": dummy_b.public_key},
         },
     )
-    await program.rpc["compositeUpdate"](1234, 4321, ctx=ctx)
+    await program.rpc["composite_update"](1234, 4321, ctx=ctx)
     return initialized_accounts
 
 
@@ -67,7 +67,7 @@ async def test_composite_update(
     program: Program,
     composite_updated_accounts: Tuple[Keypair, Keypair],
 ) -> None:
-    """Test that the call to compositeUpdate worked."""
+    """Test that the call to composite_update worked."""
     dummy_a, dummy_b = composite_updated_accounts
     dummy_a_account = await program.account["DummyA"].fetch(dummy_a.public_key)
     dummy_b_account = await program.account["DummyB"].fetch(dummy_b.public_key)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -36,7 +36,7 @@ async def test_hello_err(program: Program) -> None:
 async def test_hello_no_msg_err(program: Program) -> None:
     """Test error from helloNoMsg func."""
     with raises(ProgramError) as excinfo:
-        await program.rpc["helloNoMsg"]()
+        await program.rpc["hello_no_msg"]()
     assert excinfo.value.msg == "HelloNoMsg"
     assert excinfo.value.code == 300 + 123
 
@@ -45,7 +45,7 @@ async def test_hello_no_msg_err(program: Program) -> None:
 async def test_hello_next_err(program: Program) -> None:
     """Test error from helloNext func."""
     with raises(ProgramError) as excinfo:
-        await program.rpc["helloNext"]()
+        await program.rpc["hello_next"]()
     assert excinfo.value.msg == "HelloNext"
     assert excinfo.value.code == 300 + 124
 
@@ -54,8 +54,8 @@ async def test_hello_next_err(program: Program) -> None:
 async def test_mut_err(program: Program) -> None:
     """Test mmut error."""
     with raises(ProgramError) as excinfo:
-        await program.rpc["mutError"](
-            ctx=Context(accounts={"myAccount": SYSVAR_RENT_PUBKEY})
+        await program.rpc["mut_error"](
+            ctx=Context(accounts={"my_account": SYSVAR_RENT_PUBKEY})
         )
     assert excinfo.value.msg == "A mut constraint was violated"
     assert excinfo.value.code == 140
@@ -66,10 +66,10 @@ async def test_has_one_err(program: Program) -> None:
     """Test hasOneError."""
     account = Keypair()
     with raises(ProgramError) as excinfo:
-        await program.rpc["hasOneError"](
+        await program.rpc["has_one_error"](
             ctx=Context(
                 accounts={
-                    "myAccount": account.public_key,
+                    "my_account": account.public_key,
                     "owner": SYSVAR_RENT_PUBKEY,
                     "rent": SYSVAR_RENT_PUBKEY,
                 },
@@ -97,7 +97,7 @@ async def test_signer_err(program: Program) -> None:
                 ),
             ],
             program_id=program.program_id,
-            data=program.coder.instruction.encode("signerError", {}),
+            data=program.coder.instruction.encode("signer_error", {}),
         ),
     )
     with raises(RPCException) as excinfo:

--- a/tests/test_escrow.py
+++ b/tests/test_escrow.py
@@ -144,15 +144,15 @@ async def initialize_escrow(
     ctx = Context(
         accounts={
             "initializer": provider.wallet.public_key,
-            "initializerDepositTokenAccount": initializer_token_account_a,
-            "initializerReceiveTokenAccount": initializer_token_account_b,
-            "escrowAccount": escrow_account.public_key,
-            "systemProgram": SYS_PROGRAM_ID,
-            "tokenProgram": TOKEN_PROGRAM_ID,
+            "initializer_deposit_token_account": initializer_token_account_a,
+            "initializer_receive_token_account": initializer_token_account_b,
+            "escrow_account": escrow_account.public_key,
+            "system_program": SYS_PROGRAM_ID,
+            "token_program": TOKEN_PROGRAM_ID,
         },
         signers=[escrow_account],
     )
-    await program.rpc["initializeEscrow"](INITIALIZER_AMOUNT, TAKER_AMOUNT, ctx=ctx)
+    await program.rpc["initialize_escrow"](INITIALIZER_AMOUNT, TAKER_AMOUNT, ctx=ctx)
     pda, _ = PublicKey.find_program_address([b"escrow"], program.program_id)
     return escrow_account, pda
 
@@ -183,11 +183,15 @@ async def test_initialize_escrow(
     assert _initializer_token_account_a.owner == pda
 
     # Check that the values in the escrow account match what we expect.
-    assert _escrow_account.initializerKey == provider.wallet.public_key
-    assert _escrow_account.initializerAmount == INITIALIZER_AMOUNT
-    assert _escrow_account.takerAmount == TAKER_AMOUNT
-    assert _escrow_account.initializerDepositTokenAccount == initializer_token_account_a
-    assert _escrow_account.initializerReceiveTokenAccount == initializer_token_account_b
+    assert _escrow_account.initializer_key == provider.wallet.public_key
+    assert _escrow_account.initializer_amount == INITIALIZER_AMOUNT
+    assert _escrow_account.taker_amount == TAKER_AMOUNT
+    assert (
+        _escrow_account.initializer_deposit_token_account == initializer_token_account_a
+    )
+    assert (
+        _escrow_account.initializer_receive_token_account == initializer_token_account_b
+    )
 
 
 @mark.asyncio
@@ -211,14 +215,14 @@ async def test_exchange_escrow(
         ctx=Context(
             accounts={
                 "taker": provider.wallet.public_key,
-                "takerDepositTokenAccount": taker_token_account_b,
-                "takerReceiveTokenAccount": taker_token_account_a,
-                "pdaDepositTokenAccount": initializer_token_account_a,
-                "initializerReceiveTokenAccount": initializer_token_account_b,
-                "initializerMainAccount": provider.wallet.public_key,
-                "escrowAccount": escrow_account.public_key,
-                "pdaAccount": pda,
-                "tokenProgram": TOKEN_PROGRAM_ID,
+                "taker_deposit_token_account": taker_token_account_b,
+                "taker_receive_token_account": taker_token_account_a,
+                "pda_deposit_token_account": initializer_token_account_a,
+                "initializer_receive_token_account": initializer_token_account_b,
+                "initializer_main_account": provider.wallet.public_key,
+                "escrow_account": escrow_account.public_key,
+                "pda_account": pda,
+                "token_program": TOKEN_PROGRAM_ID,
             },
         )
     )
@@ -265,17 +269,17 @@ async def test_init_and_cancel_escrow(
         opts=provider.opts,
     )
     new_escrow = Keypair()
-    await program.rpc["initializeEscrow"](
+    await program.rpc["initialize_escrow"](
         INITIALIZER_AMOUNT,
         TAKER_AMOUNT,
         ctx=Context(
             accounts={
                 "initializer": provider.wallet.public_key,
-                "initializerDepositTokenAccount": initializer_token_account_a,
-                "initializerReceiveTokenAccount": initializer_token_account_b,
-                "escrowAccount": new_escrow.public_key,
-                "systemProgram": SYS_PROGRAM_ID,
-                "tokenProgram": TOKEN_PROGRAM_ID,
+                "initializer_deposit_token_account": initializer_token_account_a,
+                "initializer_receive_token_account": initializer_token_account_b,
+                "escrow_account": new_escrow.public_key,
+                "system_program": SYS_PROGRAM_ID,
+                "token_program": TOKEN_PROGRAM_ID,
             },
             signers=[new_escrow],
         ),
@@ -289,14 +293,14 @@ async def test_init_and_cancel_escrow(
     assert _initializer_token_account_a.owner == pda
 
     # Cancel the escrow.
-    await program.rpc["cancelEscrow"](
+    await program.rpc["cancel_escrow"](
         ctx=Context(
             accounts={
                 "initializer": provider.wallet.public_key,
-                "pdaDepositTokenAccount": initializer_token_account_a,
-                "pdaAccount": pda,
-                "escrowAccount": new_escrow.public_key,
-                "tokenProgram": TOKEN_PROGRAM_ID,
+                "pda_deposit_token_account": initializer_token_account_a,
+                "pda_account": pda,
+                "escrow_account": new_escrow.public_key,
+                "token_program": TOKEN_PROGRAM_ID,
             },
         )
     )

--- a/tests/test_multisig.py
+++ b/tests/test_multisig.py
@@ -45,7 +45,7 @@ async def created_multisig(program: Program) -> CreatedMultisig:
     owner_a, owner_b, owner_c = Keypair(), Keypair(), Keypair()
     owners = [owner_a.public_key, owner_b.public_key, owner_c.public_key]
     threshold = 2
-    await program.rpc["createMultisig"](
+    await program.rpc["create_multisig"](
         owners,
         threshold,
         nonce,
@@ -87,20 +87,20 @@ async def created_transaction(
     accounts = [
         program.type["TransactionAccount"](
             pubkey=multisig.public_key,
-            isWritable=True,
-            isSigner=False,
+            is_writable=True,
+            is_signer=False,
         ),
         program.type["TransactionAccount"](
             pubkey=multisig_signer,
-            isWritable=False,
-            isSigner=True,
+            is_writable=False,
+            is_signer=True,
         ),
     ]
     new_owners = [*owners[:2], owner_d.public_key]
-    data = program.coder.instruction.encode("setOwners", {"owners": new_owners})
+    data = program.coder.instruction.encode("set_owners", {"owners": new_owners})
     transaction = Keypair()
     tx_size = 1000
-    await program.rpc["createTransaction"](
+    await program.rpc["create_transaction"](
         program.program_id,
         accounts,
         data,
@@ -130,11 +130,11 @@ async def test_created_transaction(
 ) -> None:
     transaction, accounts, data, multisig, _, _ = created_transaction
     tx_account = await program.account["Transaction"].fetch(transaction.public_key)
-    assert tx_account.programId == program.program_id
+    assert tx_account.program_id == program.program_id
     assert tx_account.accounts == accounts
     assert tx_account.data == data
     assert tx_account.multisig == multisig.public_key
-    assert tx_account.didExecute is False
+    assert tx_account.did_execute is False
 
 
 @fixture(scope="module")
@@ -155,8 +155,8 @@ async def executed_transaction(
             signers=[owner_b],
         ),
     )
-    remaining_accounts_raw = program.instruction["setOwners"].accounts(
-        {"multisig": multisig.public_key, "multisigSigner": multisig_signer}
+    remaining_accounts_raw = program.instruction["set_owners"].accounts(
+        {"multisig": multisig.public_key, "multisig_signer": multisig_signer}
     )
     with_corrected_signer = []
     for meta in remaining_accounts_raw:
@@ -171,12 +171,12 @@ async def executed_transaction(
     ctx = Context(
         accounts={
             "multisig": multisig.public_key,
-            "multisigSigner": multisig_signer,
+            "multisig_signer": multisig_signer,
             "transaction": transaction.public_key,
         },
         remaining_accounts=remaining_accounts,
     )
-    await program.rpc["executeTransaction"](ctx=ctx)
+    await program.rpc["execute_transaction"](ctx=ctx)
 
 
 @mark.asyncio

--- a/tests/test_pyth.py
+++ b/tests/test_pyth.py
@@ -73,7 +73,7 @@ async def set_feed_price(
     price_feed: PublicKey,
 ) -> None:
     data = await get_feed_data(oracle_program, price_feed)
-    await oracle_program.rpc["setPrice"](
+    await oracle_program.rpc["set_price"](
         int(new_price * 10 ** -data.exponent),
         ctx=Context(accounts={"price": price_feed}),
     )

--- a/tests/test_swap.py
+++ b/tests/test_swap.py
@@ -547,23 +547,23 @@ def swap_usdc_a_accounts(
 ) -> dict[str, Any]:
     market_subdict = {
         "market": market_a.state.public_key(),
-        "requestQueue": market_a.state.request_queue(),
-        "eventQueue": market_a.state.event_queue(),
+        "request_queue": market_a.state.request_queue(),
+        "event_queue": market_a.state.event_queue(),
         "bids": market_a.state.bids(),
         "asks": market_a.state.asks(),
-        "coinVault": market_a.state.base_vault(),
-        "pcVault": market_a.state.quote_vault(),
-        "vaultSigner": market_a_vault_signer,
-        "openOrders": open_orders_a.public_key,
-        "orderPayerTokenAccount": orderbook_env.god_usdc,
-        "coinWallet": orderbook_env.god_a,
+        "coin_vault": market_a.state.base_vault(),
+        "pc_vault": market_a.state.quote_vault(),
+        "vault_signer": market_a_vault_signer,
+        "open_orders": open_orders_a.public_key,
+        "order_payer_token_account": orderbook_env.god_usdc,
+        "coin_wallet": orderbook_env.god_a,
     }
     return {
         "market": market_subdict,
-        "pcWallet": orderbook_env.god_usdc,
+        "pc_wallet": orderbook_env.god_usdc,
         "authority": program.provider.wallet.public_key,
-        "dexProgram": DEX_PID,
-        "tokenProgram": TOKEN_PROGRAM_ID,
+        "dex_program": DEX_PID,
+        "token_program": TOKEN_PROGRAM_ID,
         "rent": SYSVAR_RENT_PUBKEY,
     }
 
@@ -575,7 +575,7 @@ def swap_a_usdc_accounts(
 ) -> dict[str, Any]:
     market_subdict = {
         **swap_usdc_a_accounts["market"],
-        "orderPayerTokenAccount": orderbook_env.god_a,
+        "order_payer_token_account": orderbook_env.god_a,
     }
     return {**swap_usdc_a_accounts, "market": market_subdict}
 
@@ -709,47 +709,47 @@ async def test_swap_a_to_b(
     swap_amount = 10
     from_subdict = {
         "market": market_a.state.public_key(),
-        "requestQueue": market_a.state.request_queue(),
-        "eventQueue": market_a.state.event_queue(),
+        "request_queue": market_a.state.request_queue(),
+        "event_queue": market_a.state.event_queue(),
         "bids": market_a.state.bids(),
         "asks": market_a.state.asks(),
-        "coinVault": market_a.state.base_vault(),
-        "pcVault": market_a.state.quote_vault(),
-        "vaultSigner": market_a_vault_signer,
+        "coin_vault": market_a.state.base_vault(),
+        "pc_vault": market_a.state.quote_vault(),
+        "vault_signer": market_a_vault_signer,
         # User params.
-        "openOrders": open_orders_a.public_key,
+        "open_orders": open_orders_a.public_key,
         # Swapping from A -> USDC.
-        "orderPayerTokenAccount": orderbook_env.god_a,
-        "coinWallet": orderbook_env.god_a,
+        "order_payer_token_account": orderbook_env.god_a,
+        "coin_wallet": orderbook_env.god_a,
     }
     to_subdict = {
         "market": market_b.state.public_key(),
-        "requestQueue": market_b.state.request_queue(),
-        "eventQueue": market_b.state.event_queue(),
+        "request_queue": market_b.state.request_queue(),
+        "event_queue": market_b.state.event_queue(),
         "bids": market_b.state.bids(),
         "asks": market_b.state.asks(),
-        "coinVault": market_b.state.base_vault(),
-        "pcVault": market_b.state.quote_vault(),
-        "vaultSigner": market_b_vault_signer,
+        "coin_vault": market_b.state.base_vault(),
+        "pc_vault": market_b.state.quote_vault(),
+        "vault_signer": market_b_vault_signer,
         # User params.
-        "openOrders": open_orders_b.public_key,
+        "open_orders": open_orders_b.public_key,
         # Swapping from USDC -> B.
-        "orderPayerTokenAccount": orderbook_env.god_usdc,
-        "coinWallet": orderbook_env.god_b,
+        "order_payer_token_account": orderbook_env.god_usdc,
+        "coin_wallet": orderbook_env.god_b,
     }
     accounts = {
         "from": from_subdict,
         "to": to_subdict,
-        "pcWallet": orderbook_env.god_usdc,
+        "pc_wallet": orderbook_env.god_usdc,
         "authority": program.provider.wallet.public_key,
-        "dexProgram": DEX_PID,
-        "tokenProgram": TOKEN_PROGRAM_ID,
+        "dex_program": DEX_PID,
+        "token_program": TOKEN_PROGRAM_ID,
         "rent": SYSVAR_RENT_PUBKEY,
     }
     addrs = [orderbook_env.god_a, orderbook_env.god_b, orderbook_env.god_usdc]
     deltas: list[float] = []
     async with balance_change(program.provider, addrs, deltas):
-        await program.rpc["swapTransitive"](
+        await program.rpc["swap_transitive"](
             int(swap_amount * 10 ** 6),
             int(swap_amount - 1),
             ctx=Context(
@@ -777,47 +777,47 @@ async def test_swap_b_to_a(
     swap_amount = 23
     from_subdict = {
         "market": market_b.state.public_key(),
-        "requestQueue": market_b.state.request_queue(),
-        "eventQueue": market_b.state.event_queue(),
+        "request_queue": market_b.state.request_queue(),
+        "event_queue": market_b.state.event_queue(),
         "bids": market_b.state.bids(),
         "asks": market_b.state.asks(),
-        "coinVault": market_b.state.base_vault(),
-        "pcVault": market_b.state.quote_vault(),
-        "vaultSigner": market_b_vault_signer,
+        "coin_vault": market_b.state.base_vault(),
+        "pc_vault": market_b.state.quote_vault(),
+        "vault_signer": market_b_vault_signer,
         # User params.
-        "openOrders": open_orders_b.public_key,
+        "open_orders": open_orders_b.public_key,
         # Swapping from B -> USDC.
-        "orderPayerTokenAccount": orderbook_env.god_b,
-        "coinWallet": orderbook_env.god_b,
+        "order_payer_token_account": orderbook_env.god_b,
+        "coin_wallet": orderbook_env.god_b,
     }
     to_subdict = {
         "market": market_a.state.public_key(),
-        "requestQueue": market_a.state.request_queue(),
-        "eventQueue": market_a.state.event_queue(),
+        "request_queue": market_a.state.request_queue(),
+        "event_queue": market_a.state.event_queue(),
         "bids": market_a.state.bids(),
         "asks": market_a.state.asks(),
-        "coinVault": market_a.state.base_vault(),
-        "pcVault": market_a.state.quote_vault(),
-        "vaultSigner": market_a_vault_signer,
+        "coin_vault": market_a.state.base_vault(),
+        "pc_vault": market_a.state.quote_vault(),
+        "vault_signer": market_a_vault_signer,
         # User params.
-        "openOrders": open_orders_a.public_key,
+        "open_orders": open_orders_a.public_key,
         # Swapping from USDC -> B.
-        "orderPayerTokenAccount": orderbook_env.god_usdc,
-        "coinWallet": orderbook_env.god_a,
+        "order_payer_token_account": orderbook_env.god_usdc,
+        "coin_wallet": orderbook_env.god_a,
     }
     accounts = {
         "from": from_subdict,
         "to": to_subdict,
-        "pcWallet": orderbook_env.god_usdc,
+        "pc_wallet": orderbook_env.god_usdc,
         "authority": program.provider.wallet.public_key,
-        "dexProgram": DEX_PID,
-        "tokenProgram": TOKEN_PROGRAM_ID,
+        "dex_program": DEX_PID,
+        "token_program": TOKEN_PROGRAM_ID,
         "rent": SYSVAR_RENT_PUBKEY,
     }
     addrs = [orderbook_env.god_a, orderbook_env.god_b, orderbook_env.god_usdc]
     deltas: list[float] = []
     async with balance_change(program.provider, addrs, deltas):
-        await program.rpc["swapTransitive"](
+        await program.rpc["swap_transitive"](
             int(swap_amount * 10 ** 6),
             int(swap_amount - 1),
             ctx=Context(

--- a/tests/test_sysvars.py
+++ b/tests/test_sysvars.py
@@ -28,7 +28,7 @@ async def test_init(localnet) -> None:
             accounts={
                 "clock": SYSVAR_CLOCK_PUBKEY,
                 "rent": SYSVAR_RENT_PUBKEY,
-                "stakeHistory": SYSVAR_STAKE_HISTORY_PUBKEY,
+                "stake_history": SYSVAR_STAKE_HISTORY_PUBKEY,
             }
         )
     )

--- a/tests/test_token_proxy.py
+++ b/tests/test_token_proxy.py
@@ -98,14 +98,14 @@ async def mint_token(
     created_mint: PublicKey,
     from_pubkey: PublicKey,
 ) -> None:
-    await program.rpc["proxyMintTo"](
+    await program.rpc["proxy_mint_to"](
         1000,
         ctx=Context(
             accounts={
                 "authority": provider.wallet.public_key,
                 "mint": created_mint,
                 "to": from_pubkey,
-                "tokenProgram": TOKEN_PROGRAM_ID,
+                "token_program": TOKEN_PROGRAM_ID,
             },
         ),
     )
@@ -127,14 +127,14 @@ async def transfer_token(
     from_pubkey: PublicKey,
     mint_token: None,
 ) -> None:
-    await program.rpc["proxyTransfer"](
+    await program.rpc["proxy_transfer"](
         400,
         ctx=Context(
             accounts={
                 "authority": provider.wallet.public_key,
                 "to": to_pubkey,
                 "from": from_pubkey,
-                "tokenProgram": TOKEN_PROGRAM_ID,
+                "token_program": TOKEN_PROGRAM_ID,
             },
         ),
     )
@@ -161,14 +161,14 @@ async def burn_token(
     created_mint: PublicKey,
     transfer_token: None,
 ) -> None:
-    await program.rpc["proxyBurn"](
+    await program.rpc["proxy_burn"](
         399,
         ctx=Context(
             accounts={
                 "authority": provider.wallet.public_key,
                 "mint": created_mint,
                 "to": to_pubkey,
-                "tokenProgram": TOKEN_PROGRAM_ID,
+                "token_program": TOKEN_PROGRAM_ID,
             },
         ),
     )
@@ -195,14 +195,14 @@ async def set_new_mint_authority(
 ) -> PublicKey:
     new_mint_authority = Keypair()
     authority_type = program.type["AuthorityType"]
-    await program.rpc["proxySetAuthority"](
+    await program.rpc["proxy_set_authority"](
         authority_type.MintTokens(),
         new_mint_authority.public_key,
         ctx=Context(
             accounts={
-                "accountOrMint": created_mint,
-                "currentAuthority": provider.wallet.public_key,
-                "tokenProgram": TOKEN_PROGRAM_ID,
+                "account_or_mint": created_mint,
+                "current_authority": provider.wallet.public_key,
+                "token_program": TOKEN_PROGRAM_ID,
             },
         ),
     )

--- a/tests/test_zero_copy.py
+++ b/tests/test_zero_copy.py
@@ -44,13 +44,14 @@ async def program_cpi(workspace: dict[str, Program]) -> Program:
 @fixture(scope="module")
 async def provider(program: Program) -> Provider:
     """Get a Provider instance."""
+    print(program.idl)
     return program.provider
 
 
 @fixture(scope="module")
 async def foo(program: Program) -> Keypair:
     foo_keypair = Keypair()
-    await program.rpc["createFoo"](
+    await program.rpc["create_foo"](
         ctx=Context(
             accounts={
                 "foo": foo_keypair.public_key,
@@ -69,13 +70,13 @@ async def test_create_foo(foo: Keypair, provider: Provider, program: Program) ->
     account = await program.account["Foo"].fetch(foo.public_key)
     assert account.authority == provider.wallet.public_key
     assert account.data == 0
-    assert account.secondData == 0
-    assert account.secondAuthority == list(bytes(provider.wallet.public_key))
+    assert account.second_data == 0
+    assert account.second_authority == list(bytes(provider.wallet.public_key))
 
 
 @fixture(scope="module")
 async def update_foo(program: Program, foo: Keypair) -> None:
-    await program.rpc["updateFoo"](
+    await program.rpc["update_foo"](
         1234,
         ctx=Context(
             accounts={
@@ -93,18 +94,18 @@ async def test_update_foo(
     account = await program.account["Foo"].fetch(foo.public_key)
     assert account.authority == provider.wallet.public_key
     assert account.data == 1234
-    assert account.secondData == 0
-    assert account.secondAuthority == list(bytes(program.provider.wallet.public_key))
+    assert account.second_data == 0
+    assert account.second_authority == list(bytes(program.provider.wallet.public_key))
 
 
 @fixture(scope="module")
 async def update_foo_second(program: Program, foo: Keypair, update_foo: None) -> None:
-    await program.rpc["updateFooSecond"](
+    await program.rpc["update_foo_second"](
         55,
         ctx=Context(
             accounts={
                 "foo": foo.public_key,
-                "secondAuthority": program.provider.wallet.public_key,
+                "second_authority": program.provider.wallet.public_key,
             },
         ),
     )
@@ -117,8 +118,8 @@ async def test_update_foo_second(
     account = await program.account["Foo"].fetch(foo.public_key)
     assert account.authority == provider.wallet.public_key
     assert account.data == 1234
-    assert account.secondData == 55
-    assert account.secondAuthority == list(bytes(program.provider.wallet.public_key))
+    assert account.second_data == 55
+    assert account.second_authority == list(bytes(program.provider.wallet.public_key))
 
 
 @fixture(scope="module")
@@ -128,13 +129,13 @@ async def bar(
     bar_pubkey = PublicKey.find_program_address(
         [bytes(provider.wallet.public_key), bytes(foo.public_key)], program.program_id
     )[0]
-    await program.rpc["createBar"](
+    await program.rpc["create_bar"](
         ctx=Context(
             accounts={
                 "bar": bar_pubkey,
                 "authority": provider.wallet.public_key,
                 "foo": foo.public_key,
-                "systemProgram": SYS_PROGRAM_ID,
+                "system_program": SYS_PROGRAM_ID,
             }
         )
     )
@@ -155,7 +156,7 @@ async def update_associated_zero_copy_account(
     foo: Keypair,
     bar: PublicKey,
 ) -> None:
-    await program.rpc["updateBar"](
+    await program.rpc["update_bar"](
         99,
         ctx=Context(
             accounts={
@@ -188,14 +189,14 @@ async def check_cpi(
     bar: PublicKey,
     update_associated_zero_copy_account: None,
 ) -> None:
-    await program_cpi.rpc["checkCpi"](
+    await program_cpi.rpc["check_cpi"](
         1337,
         ctx=Context(
             accounts={
                 "bar": bar,
                 "authority": provider.wallet.public_key,
                 "foo": foo.public_key,
-                "zeroCopyProgram": program.program_id,
+                "zero_copy_program": program.program_id,
             },
         ),
     )
@@ -220,10 +221,10 @@ async def event_q(
 ) -> Keypair:
     event_q_keypair = Keypair()
     size = 1000000 + 8
-    await program.rpc["createLargeAccount"](
+    await program.rpc["create_large_account"](
         ctx=Context(
             accounts={
-                "eventQ": event_q_keypair.public_key,
+                "event_q": event_q_keypair.public_key,
                 "rent": SYSVAR_RENT_PUBKEY,
             },
             instructions=[
@@ -256,12 +257,12 @@ async def test_update_event_q(
     provider: Provider,
     event_q: Keypair,
 ) -> None:
-    await program.rpc["updateLargeAccount"](
+    await program.rpc["update_large_account"](
         0,
         48,
         ctx=Context(
             accounts={
-                "eventQ": event_q.public_key,
+                "event_q": event_q.public_key,
                 "from": provider.wallet.public_key,
             },
         ),
@@ -276,12 +277,12 @@ async def test_update_event_q(
         else:
             assert event.from_ == DEFAULT_PUBKEY
             assert event.data == 0
-    await program.rpc["updateLargeAccount"](
+    await program.rpc["update_large_account"](
         11111,
         1234,
         ctx=Context(
             accounts={
-                "eventQ": event_q.public_key,
+                "event_q": event_q.public_key,
                 "from": provider.wallet.public_key,
             },
         ),
@@ -299,12 +300,12 @@ async def test_update_event_q(
         else:
             assert event.from_ == DEFAULT_PUBKEY
             assert event.data == 0
-    await program.rpc["updateLargeAccount"](
+    await program.rpc["update_large_account"](
         24999,
         99,
         ctx=Context(
             accounts={
-                "eventQ": event_q.public_key,
+                "event_q": event_q.public_key,
                 "from": provider.wallet.public_key,
             },
         ),
@@ -326,12 +327,12 @@ async def test_update_event_q(
             assert event.from_ == DEFAULT_PUBKEY
             assert event.data == 0
     with raises(RPCException):
-        await program.rpc["updateLargeAccount"](
+        await program.rpc["update_large_account"](
             25000,
             99,
             ctx=Context(
                 accounts={
-                    "eventQ": event_q.public_key,
+                    "event_q": event_q.public_key,
                     "from": provider.wallet.public_key,
                 },
             ),

--- a/tests/unit/test_accounts_array.py
+++ b/tests/unit/test_accounts_array.py
@@ -18,10 +18,10 @@ def test_accounts_array() -> None:
     dummy_b = Keypair.generate()
     comp_accounts = {
         "foo": {
-            "dummyA": dummy_a.public_key,
+            "dummy_a": dummy_a.public_key,
         },
         "bar": {
-            "dummyB": dummy_b.public_key,
+            "dummy_b": dummy_b.public_key,
         },
     }
     accounts_arg = idl.instructions[1].accounts


### PR DESCRIPTION
Make instruction names, field names and account names (for instructions) snake case. This makes the IDL names the same as the Rust names