### PR TITLE
update solana 0.23.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -107,15 +107,12 @@ toml = ["toml"]
 yaml = ["pyyaml"]
 
 [[package]]
-name = "base58"
-version = "2.1.1"
-description = "Base58 and Base58Check implementation."
+name = "based58"
+version = "0.1.1"
+description = "A fast Python library for Base58 and Base58Check"
 category = "main"
 optional = false
-python-versions = ">=3.5"
-
-[package.extras]
-tests = ["mypy", "PyHamcrest (>=2.0.2)", "pytest (>=4.6)", "pytest-benchmark", "pytest-cov", "pytest-flake8"]
+python-versions = ">=3.7"
 
 [[package]]
 name = "black"
@@ -1272,7 +1269,7 @@ python-versions = "*"
 
 [[package]]
 name = "solana"
-version = "0.21.0"
+version = "0.23.2"
 description = "Solana Python API"
 category = "main"
 optional = false
@@ -1280,16 +1277,16 @@ python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
 apischema = ">=0.16.1,<0.17.0"
-base58 = ">=2.0.1,<3.0.0"
+based58 = ">=0.1.0,<0.2.0"
 cachetools = ">=4.2.2,<5.0.0"
 construct-typing = ">=0.5.2,<0.6.0"
 httpx = ">=0.18.2,<0.19.0"
 jsonrpcclient = ">=4.0.1,<5.0.0"
-jsonrpcserver = ">=5.0.4,<6.0.0"
+jsonrpcserver = ">=5.0.7,<6.0.0"
 PyNaCl = ">=1.4.0,<2.0.0"
 requests = ">=2.24,<3.0"
 types-cachetools = ">=4.2.4,<5.0.0"
-typing-extensions = ">=3.10.0,<4.0.0"
+typing-extensions = ">=3.10.0"
 websockets = ">=10.1,<11.0"
 
 [[package]]
@@ -1512,7 +1509,7 @@ cli = ["typer", "ipython"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "9dc3f4be61de84a8591ce6901718cf8a74f14574ce3570d4af69cecd1f11dfd5"
+content-hash = "7c660e1ed53a718a6968bef737cf048ca423625e2dd4d85bb37c13648453e9a1"
 
 [metadata.files]
 anyio = [
@@ -1551,9 +1548,21 @@ bandit = [
     {file = "bandit-1.7.2-py3-none-any.whl", hash = "sha256:e20402cadfd126d85b68ed4c8862959663c8c372dbbb1fca8f8e2c9f55a067ec"},
     {file = "bandit-1.7.2.tar.gz", hash = "sha256:6d11adea0214a43813887bfe71a377b5a9955e4c826c8ffd341b494e3ab25260"},
 ]
-base58 = [
-    {file = "base58-2.1.1-py3-none-any.whl", hash = "sha256:11a36f4d3ce51dfc1043f3218591ac4eb1ceb172919cebe05b52a5bcc8d245c2"},
-    {file = "base58-2.1.1.tar.gz", hash = "sha256:c5d0cb3f5b6e81e8e35da5754388ddcc6d0d14b6c6a132cb93d69ed580a7278c"},
+based58 = [
+    {file = "based58-0.1.1-cp37-abi3-macosx_10_7_x86_64.whl", hash = "sha256:745851792ce5fada615f05ec61d7f360d19c76950d1e86163b2293c63a5d43bc"},
+    {file = "based58-0.1.1-cp37-abi3-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:f8448a71678bd1edc0a464033695686461ab9d6d0bc3282cb29b94f883583572"},
+    {file = "based58-0.1.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:852c37206374a62c5d3ef7f6777746e2ad9106beec4551539e9538633385e613"},
+    {file = "based58-0.1.1-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3fb17f0aaaad0381c8b676623c870c1a56aca039e2a7c8416e65904d80a415f7"},
+    {file = "based58-0.1.1-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:06f3c40b358b0c6fc6fc614c43bb11ef851b6d04e519ac1eda2833420cb43799"},
+    {file = "based58-0.1.1-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2a9db744be79c8087eebedbffced00c608b3ed780668ab3c59f1d16e72c84947"},
+    {file = "based58-0.1.1-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0506435e98836cc16e095e0d6dc428810e0acfb44bc2f3ac3e23e051a69c0e3e"},
+    {file = "based58-0.1.1-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8937e97fa8690164fd11a7c642f6d02df58facd2669ae7355e379ab77c48c924"},
+    {file = "based58-0.1.1-cp37-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:14b01d91ac250300ca7f634e5bf70fb2b1b9aaa90cc14357943c7da525a35aff"},
+    {file = "based58-0.1.1-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:aba18f6c869fade1d1551fe398a376440771d6ce288c54cba71b7090cf08af02"},
+    {file = "based58-0.1.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ae7f17b67bf0c209da859a6b833504aa3b19dbf423cbd2369aa17e89299dc972"},
+    {file = "based58-0.1.1-cp37-abi3-win32.whl", hash = "sha256:d8dece575de525c1ad889d9ab239defb7a6ceffc48f044fe6e14a408fb05bef4"},
+    {file = "based58-0.1.1-cp37-abi3-win_amd64.whl", hash = "sha256:ab85804a401a7b5a7141fbb14ef5b5f7d85288357d1d3f0085d47e616cef8f5a"},
+    {file = "based58-0.1.1.tar.gz", hash = "sha256:80804b346b34196c89dc7a3dc89b6021f910f4cd75aac41d433ca1880b1672dc"},
 ]
 black = [
     {file = "black-21.12b0-py3-none-any.whl", hash = "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"},
@@ -2152,8 +2161,8 @@ snowballstemmer = [
     {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
 ]
 solana = [
-    {file = "solana-0.21.0-py3-none-any.whl", hash = "sha256:f78e605228bacf5a0d3052c2e7027079c5b77820beb877572abb6dfbd17156df"},
-    {file = "solana-0.21.0.tar.gz", hash = "sha256:a2c01c750559d39a6da820eb4c16833b90fd5bfcd3245af73a6c97db2b0c7e30"},
+    {file = "solana-0.23.2-py3-none-any.whl", hash = "sha256:6c43a6013bc0b5358cafd94a4fa091d30f7917fe578960329a8977b9dd1b21a5"},
+    {file = "solana-0.23.2.tar.gz", hash = "sha256:57c98be97d944440146780a4e175c0dbf50a988d75f05d81b5083620bf4331b0"},
 ]
 stack-data = [
     {file = "stack_data-0.2.0-py3-none-any.whl", hash = "sha256:999762f9c3132308789affa03e9271bbbe947bf78311851f4d485d8402ed858e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = ["kevinheavey <kevinheavey123@gmail.com>"]
 [tool.poetry.dependencies]
 python = "^3.9"
 construct-typing = "^0.5.1"
-solana = "^0.21.0"
+solana = "^0.23.1"
 sumtypes = "^0.1a6"
 apischema = "^0.16.6"
 borsh-construct = "^0.1.0"

--- a/src/anchorpy/program/namespace/account.py
+++ b/src/anchorpy/program/namespace/account.py
@@ -1,7 +1,7 @@
 """Provides the `AccountClient` class."""
 import base64
 from dataclasses import dataclass
-from base58 import b58encode
+from based58 import b58encode
 from typing import Any, Optional, Dict, List
 
 from construct import Container


### PR DESCRIPTION
This update is required to avoid a version conflict with solana and use the RPC method `getBlockHeight`. 

https://github.com/michaelhly/solana-py/blob/master/CHANGELOG.md#0220---2022-03-03