### PR TITLE
fix(clientgen): add missing BorshPubkey import in defined types

### DIFF
--- a/src/anchorpy/clientgen/types.py
+++ b/src/anchorpy/clientgen/types.py
@@ -134,6 +134,7 @@ def gen_struct(idl: Idl, name: str, fields: list[_IdlField]) -> Collection:
         FromImport("dataclasses", ["dataclass"]),
         FromImport("construct", ["Container", "Construct"]),
         FromImport("solana.publickey", ["PublicKey"]),
+        FromImport("anchorpy.borsh_extension", ["BorshPubkey"]),
         ImportAs("borsh_construct", "borsh"),
     ]
     json_interface_name = _json_interface_name(name)

--- a/tests/unit/test_clientgen.py
+++ b/tests/unit/test_clientgen.py
@@ -37,6 +37,7 @@ def test_empty_fields() -> None:
         '\nfrom dataclasses import dataclass'
         '\nfrom construct import Container, Construct'
         '\nfrom solana.publickey import PublicKey'
+        '\nfrom anchorpy.borsh_extension import BorshPubkey'
         '\nimport borsh_construct as borsh'
         '\nclass AggregatorLockParamsJSON(typing.TypedDict):'
         '\n    pass'


### PR DESCRIPTION
The `BorshPubkey` import is missing from the types1 generation for the generated client, leading to broken type structs. This addition should fix that.