### PR TITLE
Fix logical grouping issue in filters_to_use assignment

### DIFF
--- a/src/anchorpy/program/namespace/account.py
+++ b/src/anchorpy/program/namespace/account.py
@@ -193,7 +193,7 @@ class AccountClient(object):
             offset=0,
             bytes=bytes_arg,
         )
-        filters_to_use = [base_memcmp_opt] + [] if filters is None else filters
+        filters_to_use = [base_memcmp_opt] + ([] if filters is None else filters)
         resp = await self._provider.connection.get_program_accounts(
             self._program_id,
             encoding="base64",


### PR DESCRIPTION
**Description**

This pull request addresses an issue with the logical grouping in the filters_to_use assignment. The current logic does not properly handle the case where filters is not None, leading to potential runtime errors. By adding parentheses, we ensure the correct evaluation of the condition.

**Current Code**

> if `filters is None` then `[base_memcmp_opt] + []`
> else `filters`

**Issue**
As is, if filters is not None, then the account discriminator memcmp is dropped from the list of filters to use.

**Proposed Fix**

> if `filters is None` then `[base_memcmp_opt] + ([])`
> else `[base_memcmp_opt] + filters`

**Solution**
Adding parentheses ensures that the conditional expression is evaluated correctly.